### PR TITLE
Making the preview for the ColorField work with list_editable in ModelAdmin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,21 @@ Then in your models, you can use it like this::
     from django.db import models
     from colorfield.fields import ColorField
 
-
     class Show(ExtendedModel):
         title = models.CharField(u'Title', max_length=250)
         color = ColorField(default='ffffff')
+        
+And an example for the admin::
+
+    from django.contrib import admin
+    from models import Show
+    
+    ShowAdmin(admin.ModelAdmin):
+        list_display = ('title', 'color',)
+        list_editable = ('color',)
+        
+    admin.site.register(Show, ShowAdmin)
+
 
 
     

--- a/colorfield/static/colorfield/css/colorpicker.css
+++ b/colorfield/static/colorfield/css/colorpicker.css
@@ -1,18 +1,24 @@
 .color-picker-preview {
     border:1px solid #ccc;
     height:23px;
-    left:122px;
-    position:absolute;
-    top:0;
     width:23px;
-    -moz-border-radius:4px;
+    border-radius:3px;
+    -moz-border-radius:3px;
+    float:left;
+    display: inline-block;
+    margin-right: 3px;
+}
+td > .color-picker-preview {
+    margin-top: -5px !important;
+    margin-bottom: -5px !important;
 }
 .color-picker-preview div {
     height:19px;
     left:2px;
-    position:absolute;
+    position:relative;
     top:2px;
     width:19px;
+    border-radius:2px;
     -moz-border-radius:2px;
 }
 .colorpicker {


### PR DESCRIPTION
Fixing a problem with the preview for the ColorField when used with list_editable in ModelAdmin. Previously only one preview would be shown, and it would be misplaced.
